### PR TITLE
Require libs we depend on

### DIFF
--- a/lib/affairs_of_state.rb
+++ b/lib/affairs_of_state.rb
@@ -1,5 +1,9 @@
 require "affairs_of_state/version"
 
+require "active_support"
+require "active_support/concern"
+require "active_record"
+
 module AffairsOfState
   extend ActiveSupport::Concern
 
@@ -64,4 +68,7 @@ module AffairsOfState
 
 end
 
-ActiveRecord::Base.send :include, AffairsOfState
+
+ActiveSupport.on_load(:active_record) do
+  ::ActiveRecord::Base.send :include, AffairsOfState
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
-require 'active_record'
-require 'active_support/all'
-require 'affairs_of_state'
-require 'pry'
+require "affairs_of_state"
+
+require "pry"
 
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
@garethson

We explicitly depend on `activesupport` and `activerecord` in the gemfile/gemspec. But we don't require them. So loading the gem in a rails app is fine. But for example if you require it outside of a rails app context such as `pry --gem` we are not explicitly requiring the classes we depend on and get the `uninitialized constante AffairsOfState::ActiveSupport`.

Remove the requires from the tests to so we are now testing that we require everything we need.